### PR TITLE
Restrict CORS to trusted origins and verify origin blocking

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,6 +11,7 @@ import json
 from threading import Lock
 from transcript_processor import TranscriptProcessor
 import time
+import os
 
 # Load environment variables
 load_dotenv()
@@ -40,13 +41,14 @@ app = FastAPI(
     version="1.0.0"
 )
 
-# Configure CORS
+# Configure CORS with environment-based trusted origins
+allowed_origins = [origin.strip() for origin in os.getenv("ALLOWED_ORIGINS", "").split(",") if origin.strip()]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],     # Allow all origins for testing
+    allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["*"],     # Allow all methods
-    allow_headers=["*"],     # Allow all headers
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type", "Cache-Control", "Pragma", "Expires"],
     max_age=3600,            # Cache preflight requests for 1 hour
 )
 

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+APP_DIR = Path(__file__).resolve().parent.parent / "app"
+sys.path.insert(0, str(APP_DIR))
+
+
+def create_app(monkeypatch, origins):
+    monkeypatch.setenv("ALLOWED_ORIGINS", ",".join(origins))
+    import main
+    importlib.reload(main)
+    return main.app
+
+
+def test_allowed_origin(monkeypatch):
+    app = create_app(monkeypatch, ["http://trusted.com"])
+    client = TestClient(app)
+    response = client.options(
+        "/get-meetings",
+        headers={
+            "Origin": "http://trusted.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "http://trusted.com"
+
+
+def test_blocked_origin(monkeypatch):
+    app = create_app(monkeypatch, ["http://trusted.com"])
+    client = TestClient(app)
+    response = client.options(
+        "/get-meetings",
+        headers={
+            "Origin": "http://malicious.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
## Summary
- load allowed CORS origins from `ALLOWED_ORIGINS` env variable
- limit permitted methods and headers for CORS requests
- add tests ensuring only trusted origins pass preflight checks

## Testing
- `cd backend && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689640f2dccc83218b83638e1e112bb6