### PR TITLE
Refactor API endpoints to noun-based routes

### DIFF
--- a/backend/API_DOCUMENTATION.md
+++ b/backend/API_DOCUMENTATION.md
@@ -91,11 +91,11 @@ Currently, no authentication is required for API endpoints.
 
 ## Endpoints
 
-### 1. Process Transcript
-Process a transcript text directly.
+### 1. Generate Summary
+Process a transcript text for a specific meeting.
 
-**Endpoint:** `/process-transcript`  
-**Method:** POST  
+**Endpoint:** `/meetings/{meeting_id}/summary`
+**Method:** POST
 **Content-Type:** `application/json`
 
 #### Request Body
@@ -118,7 +118,7 @@ Process a transcript text directly.
 ```
 
 ### 2. Upload Transcript
-Upload and process a transcript file. This endpoint provides the same functionality as `/process-transcript` but accepts a file upload instead of raw text.
+Upload and process a transcript file. This endpoint provides the same functionality as `/meetings/{meeting_id}/summary` but accepts a file upload instead of raw text.
 
 **Endpoint:** `/upload-transcript`  
 **Method:** POST  
@@ -142,15 +142,15 @@ Upload and process a transcript file. This endpoint provides the same functional
 ```
 
 ### 3. Get Summary
-Retrieve the generated summary for a specific process.
+Retrieve the generated summary for a specific meeting.
 
-**Endpoint:** `/get-summary/{process_id}`  
+**Endpoint:** `/meetings/{meeting_id}/summary`
 **Method:** GET
 
 #### Path Parameters
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| process_id | String | Yes | ID of the process to retrieve |
+| meeting_id | String | Yes | ID of the meeting to retrieve |
 
 #### Response Codes
 | Code | Description |
@@ -274,7 +274,7 @@ curl -X POST -F "file=@transcript.txt" http://localhost:5167/upload-transcript
 
 ### 2. Check Processing Status
 ```bash
-curl http://localhost:5167/get-summary/1a2e5c9c-a35f-452f-9f92-be66620fcb3f
+curl http://localhost:5167/meetings/1a2e5c9c-a35f-452f-9f92-be66620fcb3f/summary
 ```
 
 ## Notes

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,11 +71,7 @@ class MeetingDetailsResponse(BaseModel):
     transcripts: List[Transcript]
 
 class MeetingTitleUpdate(BaseModel):
-    meeting_id: str
     title: str
-
-class DeleteMeetingRequest(BaseModel):
-    meeting_id: str
 
 class SaveTranscriptRequest(BaseModel):
     meeting_title: str
@@ -88,11 +84,10 @@ class SaveModelConfigRequest(BaseModel):
     apiKey: Optional[str] = None
 
 class TranscriptRequest(BaseModel):
-    """Request model for transcript text, updated with meeting_id"""
+    """Request model for transcript text"""
     text: str
     model: str
     model_name: str
-    meeting_id: str
     chunk_size: Optional[int] = 5000
     overlap: Optional[int] = 1000
 
@@ -157,7 +152,7 @@ class SummaryProcessor:
 processor = SummaryProcessor()
 
 # New meeting management endpoints
-@app.get("/get-meetings", response_model=List[MeetingResponse])
+@app.get("/meetings", response_model=List[MeetingResponse])
 async def get_meetings():
     """Get all meetings with their basic information"""
     try:
@@ -167,7 +162,7 @@ async def get_meetings():
         logger.error(f"Error getting meetings: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/get-meeting/{meeting_id}", response_model=MeetingDetailsResponse)
+@app.get("/meetings/{meeting_id}", response_model=MeetingDetailsResponse)
 async def get_meeting(meeting_id: str):
     """Get a specific meeting by ID with all its details"""
     try:
@@ -181,21 +176,21 @@ async def get_meeting(meeting_id: str):
         logger.error(f"Error getting meeting: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/save-meeting-title")
-async def save_meeting_title(data: MeetingTitleUpdate):
+@app.post("/meetings/{meeting_id}/title")
+async def save_meeting_title(meeting_id: str, data: MeetingTitleUpdate):
     """Save a meeting title"""
     try:
-        await db.update_meeting_title(data.meeting_id, data.title)
+        await db.update_meeting_title(meeting_id, data.title)
         return {"message": "Meeting title saved successfully"}
     except Exception as e:
         logger.error(f"Error saving meeting title: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/delete-meeting")
-async def delete_meeting(data: DeleteMeetingRequest):
+@app.delete("/meetings/{meeting_id}")
+async def delete_meeting(meeting_id: str):
     """Delete a meeting and all its associated data"""
     try:
-        success = await db.delete_meeting(data.meeting_id)
+        success = await db.delete_meeting(meeting_id)
         if success:
             return {"message": "Meeting deleted successfully"}
         else:
@@ -204,7 +199,7 @@ async def delete_meeting(data: DeleteMeetingRequest):
         logger.error(f"Error deleting meeting: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
-async def process_transcript_background(process_id: str, transcript: TranscriptRequest):
+async def process_transcript_background(process_id: str, meeting_id: str, transcript: TranscriptRequest):
     """Background task to process transcript"""
     try:
         logger.info(f"Starting background processing for process_id: {process_id}")
@@ -246,7 +241,7 @@ async def process_transcript_background(process_id: str, transcript: TranscriptR
 
         # Update database with meeting name using meeting_id
         if final_summary["MeetingName"]:
-            await processor.db.update_meeting_name(transcript.meeting_id, final_summary["MeetingName"])
+            await processor.db.update_meeting_name(meeting_id, final_summary["MeetingName"])
 
         # Save final result
         if all_json_data:
@@ -265,19 +260,20 @@ async def process_transcript_background(process_id: str, transcript: TranscriptR
         except Exception as db_e:
             logger.error(f"Failed to update DB status to failed for {process_id}: {db_e}", exc_info=True)
 
-@app.post("/process-transcript")
+@app.post("/meetings/{meeting_id}/summary")
 async def process_transcript_api(
+    meeting_id: str,
     transcript: TranscriptRequest,
     background_tasks: BackgroundTasks
 ):
     """Process a transcript text with background processing"""
     try:
         # Create new process linked to meeting_id
-        process_id = await processor.db.create_process(transcript.meeting_id)
+        process_id = await processor.db.create_process(meeting_id)
 
         # Save transcript data associated with meeting_id
         await processor.db.save_transcript(
-            transcript.meeting_id,
+            meeting_id,
             transcript.text,
             transcript.model,
             transcript.model_name,
@@ -289,6 +285,7 @@ async def process_transcript_api(
         background_tasks.add_task(
             process_transcript_background,
             process_id,
+            meeting_id,
             transcript
         )
 
@@ -301,7 +298,7 @@ async def process_transcript_api(
         logger.error(f"Error in process_transcript_api: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/get-summary/{meeting_id}")
+@app.get("/meetings/{meeting_id}/summary")
 async def get_summary(meeting_id: str):
     """Get the summary for a given meeting ID"""
     try:
@@ -394,9 +391,9 @@ async def get_summary(meeting_id: str):
             }
         )
 
-@app.post("/save-transcript")
-async def save_transcript(request: SaveTranscriptRequest):
-    """Save transcript segments for a meeting without processing"""
+@app.post("/meetings")
+async def create_meeting(request: SaveTranscriptRequest):
+    """Create a meeting and save transcript segments without processing"""
     try:
         logger.info(f"Received save-transcript request for meeting: {request.meeting_title}")
         logger.info(f"Number of transcripts to save: {len(request.transcripts)}")
@@ -424,7 +421,7 @@ async def save_transcript(request: SaveTranscriptRequest):
         logger.error(f"Error saving transcript: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/get-model-config")
+@app.get("/model-config")
 async def get_model_config():
     """Get the current model configuration"""
     model_config = await db.get_model_config()
@@ -433,7 +430,7 @@ async def get_model_config():
         model_config["apiKey"] = api_key
     return model_config
 
-@app.post("/save-model-config")
+@app.post("/model-config")
 async def save_model_config(request: SaveModelConfigRequest):
     """Save the model configuration"""
     await db.save_model_config(request.provider, request.model, request.whisperModel)
@@ -441,13 +438,10 @@ async def save_model_config(request: SaveModelConfigRequest):
         await db.save_api_key(request.apiKey, request.provider)
     return {"status": "success", "message": "Model configuration saved successfully"}  
 
-class GetApiKeyRequest(BaseModel):
-    provider: str
-
-@app.post("/get-api-key")
-async def get_api_key(request: GetApiKeyRequest):
+@app.get("/api-key/{provider}")
+async def get_api_key(provider: str):
     """Get the API key for a given provider"""
-    return await db.get_api_key(request.provider)
+    return await db.get_api_key(provider)
 
 
 

--- a/backend/debug_cors.py
+++ b/backend/debug_cors.py
@@ -1,13 +1,13 @@
 """
-Debug script to test the /process-transcript endpoint
+Debug script to test the /meetings/{meeting_id}/summary endpoint
 """
 import requests
 import json
 import sys
 
-def test_process_transcript(text="This is a test transcript"):
-    """Test the process-transcript endpoint"""
-    url = "http://localhost:5167/process-transcript"
+def test_process_transcript(meeting_id="test-meeting", text="This is a test transcript"):
+    """Test the summary processing endpoint"""
+    url = f"http://localhost:5167/meetings/{meeting_id}/summary"
     
     payload = {
         "text": text,
@@ -41,4 +41,4 @@ def test_process_transcript(text="This is a test transcript"):
 
 if __name__ == "__main__":
     text = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "This is a test transcript"
-    test_process_transcript(text)
+    test_process_transcript(text=text)

--- a/frontend/src/app/meeting-details/page-content.tsx
+++ b/frontend/src/app/meeting-details/page-content.tsx
@@ -32,7 +32,7 @@ export default function PageContent({ meeting, summaryData }: { meeting: any, su
   useEffect(() => {
     const fetchModelConfig = async () => {
       try {
-        const response = await fetch('http://localhost:5167/get-model-config');
+        const response = await fetch('http://localhost:5167/model-config');
         const data = await response.json();
         if (data.provider !== null) {
           setModelConfig(data);
@@ -65,14 +65,13 @@ export default function PageContent({ meeting, summaryData }: { meeting: any, su
       
       // Process transcript and get process_id
       console.log('Processing transcript...');
-      const response = await fetch('http://localhost:5167/process-transcript', {
+      const response = await fetch(`http://localhost:5167/meetings/${meeting.id}/summary`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           text: fullTranscript,
           model: modelConfig.provider,
           model_name: modelConfig.model,
-          meeting_id: meeting.id,
           chunk_size: 40000,
           overlap: 1000
         }),
@@ -92,7 +91,7 @@ export default function PageContent({ meeting, summaryData }: { meeting: any, su
       // Poll for summary status
       const pollInterval = setInterval(async () => {
         try {
-          const statusResponse = await fetch(`http://localhost:5167/get-summary/${process_id}`);
+          const statusResponse = await fetch(`http://localhost:5167/meetings/${process_id}/summary`);
 
           if (!statusResponse.ok) {
             const errorData = await statusResponse.json();
@@ -221,14 +220,13 @@ export default function PageContent({ meeting, summaryData }: { meeting: any, su
       
       // Process transcript and get process_id
       console.log('Processing transcript...');
-      const response = await fetch('http://localhost:5167/process-transcript', {
+      const response = await fetch(`http://localhost:5167/meetings/${meeting.id}/summary`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           text: originalTranscript,
           model: modelConfig.provider,
           model_name: modelConfig.model,
-          meeting_id: meeting.id,
           chunk_size: 40000,
           overlap: 1000
         })
@@ -246,7 +244,7 @@ export default function PageContent({ meeting, summaryData }: { meeting: any, su
       // Poll for summary status
       const pollInterval = setInterval(async () => {
         try {
-          const statusResponse = await fetch(`http://localhost:5167/get-summary/${process_id}`);
+          const statusResponse = await fetch(`http://localhost:5167/meetings/${process_id}/summary`);
           if (!statusResponse.ok) {
             const errorData = await statusResponse.json();
             console.error('Get summary failed:', errorData);
@@ -351,18 +349,12 @@ export default function PageContent({ meeting, summaryData }: { meeting: any, su
 
   const handleSaveMeetingTitle = async () => {
     try {
-      const payload = {
-        meeting_id: meeting.id,
-        title: meetingTitle
-      };
-      console.log('Saving meeting title with payload:', payload);
-      
-      const response = await fetch('http://localhost:5167/save-meeting-title', {
+      const response = await fetch(`http://localhost:5167/meetings/${meeting.id}/title`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(payload)
+        body: JSON.stringify({ title: meetingTitle })
       });
 
       if (!response.ok) {
@@ -398,7 +390,7 @@ export default function PageContent({ meeting, summaryData }: { meeting: any, su
       };
       console.log('Saving model config with payload:', payload);
       
-      const response = await fetch('http://localhost:5167/save-model-config', {
+      const response = await fetch('http://localhost:5167/model-config', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/app/meeting-details/page.tsx
+++ b/frontend/src/app/meeting-details/page.tsx
@@ -42,7 +42,7 @@ export default function MeetingDetails() {
 
     const fetchMeetingDetails = async () => {
       try {
-        const response = await fetch(`http://localhost:5167/get-meeting/${currentMeeting.id}`, {
+        const response = await fetch(`http://localhost:5167/meetings/${currentMeeting.id}`, {
           cache: 'no-store',
         });
         if (!response.ok) {
@@ -59,7 +59,7 @@ export default function MeetingDetails() {
 
     const fetchMeetingSummary = async () => {
       try {
-        const summaryResponse = await fetch(`http://localhost:5167/get-summary/${currentMeeting.id}`, {
+        const summaryResponse = await fetch(`http://localhost:5167/meetings/${currentMeeting.id}/summary`, {
           cache: 'no-store',
         });
         if (!summaryResponse.ok) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -64,7 +64,7 @@ export default function Home() {
   const [error, setError] = useState<string>('');
   const [showModelSettings, setShowModelSettings] = useState(false);
 
-  const { setCurrentMeeting, setMeetings ,meetings, isMeetingActive, setIsMeetingActive} = useSidebar();
+  const { currentMeeting, setCurrentMeeting, setMeetings ,meetings, isMeetingActive, setIsMeetingActive} = useSidebar();
   const handleNavigation = useNavigation('', ''); // Initialize with empty values
   const router = useRouter();
 
@@ -362,7 +362,7 @@ export default function Home() {
       // Save to SQLite
       if (isCallApi) {
         console.log('Saving transcript to database...', transcripts);
-        const response = await fetch('http://localhost:5167/save-transcript', {
+        const response = await fetch('http://localhost:5167/meetings', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -438,7 +438,7 @@ export default function Home() {
       
       // Process transcript and get process_id
       console.log('Processing transcript...');
-      const response = await fetch('http://localhost:5167/process-transcript', {
+      const response = await fetch(`http://localhost:5167/meetings/${currentMeeting?.id}/summary`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -465,7 +465,7 @@ export default function Home() {
       // Poll for summary status
       const pollInterval = setInterval(async () => {
         try {
-          const statusResponse = await fetch(`http://localhost:5167/get-summary/${process_id}`);
+          const statusResponse = await fetch(`http://localhost:5167/meetings/${process_id}/summary`);
           
           if (!statusResponse.ok) {
             const errorData = await statusResponse.json();
@@ -639,7 +639,7 @@ export default function Home() {
       
       // Process transcript and get process_id
       console.log('Processing transcript...');
-      const response = await fetch('http://localhost:5167/process-transcript', {
+      const response = await fetch(`http://localhost:5167/meetings/${currentMeeting?.id}/summary`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -663,7 +663,7 @@ export default function Home() {
       // Poll for summary status
       const pollInterval = setInterval(async () => {
         try {
-          const statusResponse = await fetch(`http://localhost:5167/get-summary/${process_id}`);
+          const statusResponse = await fetch(`http://localhost:5167/meetings/${process_id}/summary`);
           
           if (!statusResponse.ok) {
             const errorData = await statusResponse.json();

--- a/frontend/src/components/ModelSettingsModal.tsx
+++ b/frontend/src/components/ModelSettingsModal.tsx
@@ -40,7 +40,7 @@ export function ModelSettingsModal({
     if (showModelSettings) {
       const fetchModelConfig = async () => {
         try {
-          const response = await fetch('http://localhost:5167/get-model-config');
+          const response = await fetch('http://localhost:5167/model-config');
           const data = await response.json();
           if (data.provider !== null) {
             setModelConfig(data);
@@ -57,13 +57,7 @@ export function ModelSettingsModal({
 
   const fetchApiKey = async (provider: string) => {
     try {
-      const response = await fetch('http://localhost:5167/get-api-key', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ provider }),
-      });
+      const response = await fetch(`http://localhost:5167/api-key/${provider}`);
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/src/components/Sidebar/SidebarProvider.tsx
+++ b/frontend/src/components/Sidebar/SidebarProvider.tsx
@@ -50,7 +50,7 @@ export function SidebarProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const fetchMeetings = async () => {
       try {
-        const response = await fetch('http://localhost:5167/get-meetings', {
+        const response = await fetch('http://localhost:5167/meetings', {
           cache: 'no-store',
           headers: {
             'Cache-Control': 'no-cache, no-store, must-revalidate',

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -23,16 +23,12 @@ const Sidebar: React.FC = () => {
 
   const handleDelete = async (itemId: string) => {
     console.log('Deleting item:', itemId);
-    const payload = {
-      meeting_id: itemId
-    };
-    const response = await fetch('http://localhost:5167/delete-meeting', {
+    const response = await fetch(`http://localhost:5167/meetings/${itemId}`, {
       cache: 'no-store',
-      method: 'POST',
+      method: 'DELETE',
       headers: {
         'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(payload)
+      }
     });
 
     if (response.ok) {


### PR DESCRIPTION
## Summary
- Rename FastAPI routes to resource-based paths like `/meetings` and `/meetings/{meeting_id}/summary`
- Align frontend fetch calls with new backend endpoints
- Update API documentation for new route structure

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689640f26c6483218500d6e36ad2ddbd