### PR TITLE
Add JWT auth with role-based access control

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,128 @@
+from datetime import datetime, timedelta
+from typing import Optional
+import os
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from pydantic import BaseModel
+
+from .db import DatabaseManager
+
+SECRET_KEY = os.getenv("SECRET_KEY", "secret-key")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+REFRESH_TOKEN_EXPIRE_DAYS = 7
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+router = APIRouter()
+
+db = DatabaseManager()
+
+
+class Token(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"
+
+
+class TokenRefresh(BaseModel):
+    refresh_token: str
+
+
+class User(BaseModel):
+    username: str
+    role: str
+
+
+async def authenticate_user(username: str, password: str) -> Optional[dict]:
+    user = await db.get_user(username)
+    if not user:
+        return None
+    if not pwd_context.verify(password, user["hashed_password"]):
+        return None
+    return user
+
+
+def create_token(data: dict, expires_delta: timedelta) -> str:
+    to_encode = data.copy()
+    expire = datetime.utcnow() + expires_delta
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+async def create_tokens(username: str, role: str) -> dict:
+    access_token = create_token(
+        {"sub": username, "role": role},
+        timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+    )
+    refresh_token = create_token(
+        {"sub": username},
+        timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+    )
+    await db.save_refresh_token(username, pwd_context.hash(refresh_token))
+    return {"access_token": access_token, "refresh_token": refresh_token, "token_type": "bearer"}
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme)) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        role: str = payload.get("role")
+        if username is None or role is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = await db.get_user(username)
+    if user is None:
+        raise credentials_exception
+    return User(username=username, role=role)
+
+
+async def get_current_active_user(current_user: User = Depends(get_current_user)) -> User:
+    return current_user
+
+
+async def get_current_active_admin(current_user: User = Depends(get_current_user)) -> User:
+    if current_user.role.lower() != "admin":
+        raise HTTPException(status_code=403, detail="Not enough permissions")
+    return current_user
+
+
+@router.post("/token", response_model=Token)
+async def login_for_access_token(form_data: OAuth2PasswordRequestForm = Depends()):
+    user = await authenticate_user(form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+        )
+    return await create_tokens(user["username"], user["role"])
+
+
+@router.post("/refresh", response_model=Token)
+async def refresh_access_token(data: TokenRefresh):
+    try:
+        payload = jwt.decode(data.refresh_token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise HTTPException(status_code=401, detail="Invalid refresh token")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    token_hash = await db.get_refresh_token_hash(username)
+    if not token_hash or not pwd_context.verify(data.refresh_token, token_hash):
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    user = await db.get_user(username)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    return await create_tokens(username, user["role"])

--- a/backend/app/transcript_processor.py
+++ b/backend/app/transcript_processor.py
@@ -8,7 +8,7 @@ from pydantic_ai.models.openai import OpenAIModel
 import logging
 import os
 from dotenv import load_dotenv
-from db import DatabaseManager
+from .db import DatabaseManager
 
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ fastapi==0.115.9
 uvicorn==0.34.0
 python-multipart==0.0.20
 aiosqlite==0.21.0
+passlib[bcrypt]==1.7.4
+python-jose[cryptography]==3.3.0

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,61 @@
+import asyncio
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app.main import app
+from app.auth import db as auth_db, pwd_context
+
+client = TestClient(app)
+
+
+async def _create_user(username: str, password: str, role: str):
+    await auth_db.create_user(username, pwd_context.hash(password), role)
+
+
+# Setup users for tests
+asyncio.run(_create_user("alice", "wonderland", "user"))
+asyncio.run(_create_user("admin", "adminpass", "admin"))
+
+
+def login(username: str, password: str):
+    return client.post(
+        "/token",
+        data={"username": username, "password": password, "grant_type": "password"},
+    )
+
+
+def test_login():
+    response = login("alice", "wonderland")
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+
+
+def test_refresh_token():
+    tokens = login("alice", "wonderland").json()
+    response = client.post("/refresh", json={"refresh_token": tokens["refresh_token"]})
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+
+
+def test_role_enforcement():
+    user_tokens = login("alice", "wonderland").json()
+    res_user = client.post(
+        "/delete-meeting",
+        json={"meeting_id": "1"},
+        headers={"Authorization": f"Bearer {user_tokens['access_token']}"},
+    )
+    assert res_user.status_code == 403
+
+    admin_tokens = login("admin", "adminpass").json()
+    res_admin = client.post(
+        "/delete-meeting",
+        json={"meeting_id": "1"},
+        headers={"Authorization": f"Bearer {admin_tokens['access_token']}"},
+    )
+    assert res_admin.status_code == 200


### PR DESCRIPTION
## Summary
- implement JWT-based login and refresh endpoints using FastAPI security utilities
- add user/refresh-token tables with hashed storage and role checks on endpoints
- cover login, token refresh and role enforcement with unit tests

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_689640f4c5a88321b666e3268b8f1c38