### PR TITLE
feat: add async summary service

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -1,0 +1,19 @@
+from celery import Celery
+import os
+
+eager = os.getenv('CELERY_TASK_ALWAYS_EAGER', 'false').lower() == 'true'
+
+celery_app = Celery(
+    'meeting_minutes_tasks',
+    broker=os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0'),
+    backend=os.getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/0'),
+)
+
+celery_app.conf.update(
+    task_always_eager=eager,
+    task_store_eager_result=eager,
+)
+
+if eager:
+    celery_app.conf.broker_url = 'memory://'
+    celery_app.conf.result_backend = 'cache+memory://'

--- a/backend/app/services/summary_service.py
+++ b/backend/app/services/summary_service.py
@@ -1,0 +1,9 @@
+class SummaryService:
+    """Generates summaries from processed transcripts."""
+
+    def generate(self, lines: list[str]) -> dict:
+        """Return a naive summary consisting of line count and first line."""
+        return {
+            'line_count': len(lines),
+            'first_line': lines[0] if lines else ''
+        }

--- a/backend/app/services/transcript_service.py
+++ b/backend/app/services/transcript_service.py
@@ -1,0 +1,6 @@
+class TranscriptService:
+    """Service responsible for basic transcript processing."""
+
+    def split_lines(self, text: str) -> list[str]:
+        """Split the transcript into individual lines."""
+        return [line.strip() for line in text.splitlines() if line.strip()]

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,12 @@
+from .celery_app import celery_app
+from .services.transcript_service import TranscriptService
+from .services.summary_service import SummaryService
+
+_transcript_service = TranscriptService()
+_summary_service = SummaryService()
+
+@celery_app.task
+def generate_summary_task(text: str) -> dict:
+    """Celery task to process transcript text and generate a summary."""
+    lines = _transcript_service.split_lines(text)
+    return _summary_service.generate(lines)

--- a/backend/app/transcript_processor.py
+++ b/backend/app/transcript_processor.py
@@ -8,7 +8,7 @@ from pydantic_ai.models.openai import OpenAIModel
 import logging
 import os
 from dotenv import load_dotenv
-from db import DatabaseManager
+from .db import DatabaseManager
 
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ fastapi==0.115.9
 uvicorn==0.34.0
 python-multipart==0.0.20
 aiosqlite==0.21.0
+celery[redis]==5.3.6
+redis==5.0.1

--- a/backend/tests/test_async_workflow.py
+++ b/backend/tests/test_async_workflow.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+os.environ['CELERY_TASK_ALWAYS_EAGER'] = 'true'
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_async_summary_workflow():
+    response = client.post('/summary/async', json={'text': 'hello\nworld'})
+    assert response.status_code == 200
+    task_id = response.json()['task_id']
+
+    result_response = client.get(f'/summary/async/{task_id}')
+    assert result_response.status_code == 200
+    data = result_response.json()
+    assert data['status'] == 'completed'
+    assert data['result']['line_count'] == 2


### PR DESCRIPTION
## Summary
- integrate Celery for async transcript summary tasks
- refactor transcript and summary logic into dedicated service modules
- add integration test covering async summary workflow

## Testing
- `cd backend && pytest tests/test_async_workflow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689640f65a7883218306da6931b6f16b