### PR TITLE
Add CRM synchronization service and tests

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,6 @@
+"""Service modules for the meeting-minutes project."""
+
+__all__ = [
+    "crm_sync",
+]
+

--- a/services/crm_sync.py
+++ b/services/crm_sync.py
@@ -1,0 +1,111 @@
+"""CRM synchronization utilities.
+
+This module provides helpers to push meeting data to various CRM systems
+including Salesforce, HubSpot and Pipedrive. Each integration supports
+basic retry logic and raises an exception when the remote service cannot
+be reached after the configured number of attempts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+import os
+import time
+
+import requests
+
+
+@dataclass
+class CRMConfig:
+    """Configuration for CRM integrations.
+
+    The configuration pulls API keys and endpoint URLs from environment
+    variables so they can be easily customised without modifying code.
+    """
+
+    salesforce_api_key: str
+    salesforce_url: str
+    hubspot_api_key: str
+    hubspot_url: str
+    pipedrive_api_key: str
+    pipedrive_url: str
+    max_retries: int = 3
+    retry_delay: float = 1.0
+
+    @classmethod
+    def from_env(cls) -> "CRMConfig":
+        """Construct a :class:`CRMConfig` from environment variables."""
+
+        return cls(
+            salesforce_api_key=os.getenv("SALESFORCE_API_KEY", ""),
+            salesforce_url=os.getenv("SALESFORCE_URL", ""),
+            hubspot_api_key=os.getenv("HUBSPOT_API_KEY", ""),
+            hubspot_url=os.getenv("HUBSPOT_URL", ""),
+            pipedrive_api_key=os.getenv("PIPEDRIVE_API_KEY", ""),
+            pipedrive_url=os.getenv("PIPEDRIVE_URL", ""),
+        )
+
+
+class CRMSync:
+    """Push meeting information to CRMs."""
+
+    def __init__(self, config: CRMConfig | None = None) -> None:
+        self.config = config or CRMConfig.from_env()
+
+    # Public API -----------------------------------------------------------------
+    def push_to_salesforce(self, meeting: Dict[str, Any]) -> Dict[str, Any]:
+        payload = self._map_salesforce(meeting)
+        headers = {"Authorization": f"Bearer {self.config.salesforce_api_key}"}
+        return self._post(self.config.salesforce_url, payload, headers)
+
+    def push_to_hubspot(self, meeting: Dict[str, Any]) -> Dict[str, Any]:
+        payload = self._map_hubspot(meeting)
+        headers = {"Authorization": f"Bearer {self.config.hubspot_api_key}"}
+        return self._post(self.config.hubspot_url, payload, headers)
+
+    def push_to_pipedrive(self, meeting: Dict[str, Any]) -> Dict[str, Any]:
+        payload = self._map_pipedrive(meeting)
+        headers = {"Authorization": f"Bearer {self.config.pipedrive_api_key}"}
+        return self._post(self.config.pipedrive_url, payload, headers)
+
+    # Internal helpers -----------------------------------------------------------
+    def _post(self, url: str, payload: Dict[str, Any], headers: Dict[str, str]) -> Dict[str, Any]:
+        for attempt in range(1, self.config.max_retries + 1):
+            try:
+                response = requests.post(url, json=payload, headers=headers, timeout=5)
+                response.raise_for_status()
+                return response.json() if response.content else {}
+            except requests.RequestException:
+                if attempt == self.config.max_retries:
+                    raise
+                time.sleep(self.config.retry_delay)
+
+        return {}
+
+    @staticmethod
+    def _map_salesforce(meeting: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "Subject": meeting.get("title"),
+            "StartDate": meeting.get("date"),
+            "Participants__c": ",".join(meeting.get("participants", [])),
+        }
+
+    @staticmethod
+    def _map_hubspot(meeting: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "properties": {
+                "meeting_title": meeting.get("title"),
+                "meeting_date": meeting.get("date"),
+                "participants": ",".join(meeting.get("participants", [])),
+            }
+        }
+
+    @staticmethod
+    def _map_pipedrive(meeting: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "title": meeting.get("title"),
+            "date": meeting.get("date"),
+            "participants": ",".join(meeting.get("participants", [])),
+        }
+

--- a/services/tests/test_crm_sync.py
+++ b/services/tests/test_crm_sync.py
@@ -1,0 +1,118 @@
+"""Tests for :mod:`services.crm_sync`.
+
+These tests mock out network calls so no actual HTTP requests are sent.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import os
+import sys
+
+import requests
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from services.crm_sync import CRMConfig, CRMSync
+
+
+MEETING: Dict[str, Any] = {
+    "title": "Sync meeting",
+    "date": "2024-01-01",
+    "participants": ["alice", "bob"],
+}
+
+
+def _make_config() -> CRMConfig:
+    return CRMConfig(
+        salesforce_api_key="sf", salesforce_url="https://sf.example/api",
+        hubspot_api_key="hs", hubspot_url="https://hs.example/api",
+        pipedrive_api_key="pd", pipedrive_url="https://pd.example/api",
+        max_retries=3, retry_delay=0.01,
+    )
+
+
+def test_salesforce_push_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _make_config()
+    sync = CRMSync(config)
+
+    calls = {"count": 0}
+
+    def fake_post(url, json, headers, timeout):  # type: ignore[override]
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise requests.ConnectionError("boom")
+
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> Dict[str, Any]:
+                return {"id": 1}
+
+            @property
+            def content(self) -> bytes:
+                return b"{}"
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    result = sync.push_to_salesforce(MEETING)
+
+    assert result == {"id": 1}
+    assert calls["count"] == 3
+
+
+def test_hubspot_push_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _make_config()
+    sync = CRMSync(config)
+
+    def fake_post(url, json, headers, timeout):  # type: ignore[override]
+        raise requests.HTTPError("bad")
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    with pytest.raises(requests.HTTPError):
+        sync.push_to_hubspot(MEETING)
+
+
+def test_pipedrive_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = _make_config()
+    sync = CRMSync(config)
+
+    captured = {}
+
+    def fake_post(url, json, headers, timeout):  # type: ignore[override]
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> Dict[str, Any]:
+                return {"success": True}
+
+            @property
+            def content(self) -> bytes:
+                return b"{}"
+
+        return Resp()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    sync.push_to_pipedrive(MEETING)
+
+    assert captured["url"] == config.pipedrive_url
+    assert captured["headers"] == {"Authorization": f"Bearer {config.pipedrive_api_key}"}
+    assert captured["json"] == {
+        "title": MEETING["title"],
+        "date": MEETING["date"],
+        "participants": "alice,bob",
+    }
+


### PR DESCRIPTION
## Summary
- add CRMConfig and CRMSync utilities for Salesforce, HubSpot and Pipedrive
- support environment-based API configuration with retry and error handling
- test CRM synchronization using mocked HTTP requests

## Testing
- `pytest services/tests/test_crm_sync.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689640fb164c83218c9ae9cddcdc1fef