### PR TITLE
refactor: consolidate meeting title endpoint

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -8,7 +8,7 @@ from jose import JWTError, jwt
 from passlib.context import CryptContext
 from pydantic import BaseModel
 
-from .db import DatabaseManager
+from db import DatabaseManager
 
 SECRET_KEY = os.getenv("SECRET_KEY", "secret-key")
 ALGORITHM = "HS256"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,12 +6,12 @@ import uvicorn
 from typing import Optional, List
 import logging
 from dotenv import load_dotenv
-from .db import DatabaseManager
+from db import DatabaseManager
 import json
 from threading import Lock
-from .transcript_processor import TranscriptProcessor
+from transcript_processor import TranscriptProcessor
 import time
-from .tasks import generate_summary_task
+from tasks import generate_summary_task
 import os
 
 
@@ -58,7 +58,7 @@ app.add_middleware(
 db = DatabaseManager()
 
 # Import authentication utilities
-from .auth import (
+from auth import (
     router as auth_router,
     get_current_active_user,
     get_current_active_admin,
@@ -196,33 +196,27 @@ async def get_meeting(meeting_id: str):
         logger.error(f"Error getting meeting: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
-
-@app.post("/save-meeting-title")
-async def save_meeting_title(
+@app.post("/meetings/{meeting_id}/title")
+async def update_meeting_title(
+    meeting_id: str,
     data: MeetingTitleUpdate,
     current_user: User = Depends(get_current_active_admin),
 ):
 
-@app.post("/meetings/{meeting_id}/title")
-async def save_meeting_title(meeting_id: str, data: MeetingTitleUpdate):
-
-    """Save a meeting title"""
+    """Update a meeting title"""
     try:
         await db.update_meeting_title(meeting_id, data.title)
-        return {"message": "Meeting title saved successfully"}
+        return {"message": "Meeting title updated successfully"}
     except Exception as e:
-        logger.error(f"Error saving meeting title: {str(e)}", exc_info=True)
+        logger.error(f"Error updating meeting title: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.post("/delete-meeting")
+@app.delete("/meetings/{meeting_id}")
 async def delete_meeting(
-    data: DeleteMeetingRequest,
+    meeting_id: str,
     current_user: User = Depends(get_current_active_admin),
 ):
-
-@app.delete("/meetings/{meeting_id}")
-async def delete_meeting(meeting_id: str):
 
     """Delete a meeting and all its associated data"""
     try:

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,6 +1,6 @@
-from .celery_app import celery_app
-from .services.transcript_service import TranscriptService
-from .services.summary_service import SummaryService
+from celery_app import celery_app
+from services.transcript_service import TranscriptService
+from services.summary_service import SummaryService
 
 _transcript_service = TranscriptService()
 _summary_service = SummaryService()

--- a/backend/app/transcript_processor.py
+++ b/backend/app/transcript_processor.py
@@ -8,7 +8,7 @@ from pydantic_ai.models.openai import OpenAIModel
 import logging
 import os
 from dotenv import load_dotenv
-from .db import DatabaseManager
+from db import DatabaseManager
 
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -3,20 +3,30 @@ from fastapi.testclient import TestClient
 
 from db import DatabaseManager
 import main
+from auth import db as auth_db, pwd_context
 
 @pytest.mark.asyncio
-async def test_save_and_delete_meeting(tmp_path):
+async def test_update_and_delete_meeting(tmp_path):
     db = DatabaseManager(str(tmp_path / "test.db"))
     main.db = db
     main.processor.db = db
     await db.save_meeting("m1", "Initial")
 
+    # Create admin user for authentication
+    await auth_db.create_user("admin_api", pwd_context.hash("adminpass"), "admin")
+
     client = TestClient(main.app)
-    resp = client.post("/save-meeting-title", json={"meeting_id": "m1", "title": "Updated"})
+    tokens = client.post(
+        "/token",
+        data={"username": "admin_api", "password": "adminpass", "grant_type": "password"},
+    ).json()
+    headers = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    resp = client.post("/meetings/m1/title", json={"title": "Updated"}, headers=headers)
     assert resp.status_code == 200
     meeting = await db.get_meeting("m1")
     assert meeting["title"] == "Updated"
 
-    resp = client.post("/delete-meeting", json={"meeting_id": "m1"})
+    resp = client.delete("/meetings/m1", headers=headers)
     assert resp.status_code == 200
     assert await db.get_meeting("m1") is None

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -45,17 +45,15 @@ def test_refresh_token():
 
 def test_role_enforcement():
     user_tokens = login("alice", "wonderland").json()
-    res_user = client.post(
-        "/delete-meeting",
-        json={"meeting_id": "1"},
+    res_user = client.delete(
+        "/meetings/1",
         headers={"Authorization": f"Bearer {user_tokens['access_token']}"},
     )
     assert res_user.status_code == 403
 
     admin_tokens = login("admin", "adminpass").json()
-    res_admin = client.post(
-        "/delete-meeting",
-        json={"meeting_id": "1"},
+    res_admin = client.delete(
+        "/meetings/1",
         headers={"Authorization": f"Bearer {admin_tokens['access_token']}"},
     )
     assert res_admin.status_code == 200

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -32,16 +32,16 @@ async def test_end_to_end_processing(tmp_path, monkeypatch):
         "text": "hello world",
         "model": "openai",
         "model_name": "gpt-test",
-        "meeting_id": "m1",
         "chunk_size": 10,
-        "overlap": 0
+        "overlap": 0,
     }
-    resp = client.post("/process-transcript", json=payload)
+    resp = client.post("/meetings/m1/summary", json=payload)
     assert resp.status_code == 200
+    process_id = resp.json()["process_id"]
 
-    await process_transcript_background("m1", TranscriptRequest(**payload))
+    await process_transcript_background(process_id, "m1", TranscriptRequest(**payload))
 
-    resp = client.get("/get-summary/m1")
+    resp = client.get("/meetings/m1/summary")
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "completed"


### PR DESCRIPTION
## Summary
- remove obsolete stubbed `/save-meeting-title` endpoint and expose `/meetings/{meeting_id}/title`
- require admin auth for meeting title updates and deletions
- update tests to exercise new endpoints and authentication

## Testing
- `cd backend && pytest` *(fails: `tests/test_async_workflow.py::test_async_summary_workflow` Connection refused to Redis)*

------
https://chatgpt.com/codex/tasks/task_e_68964e63b8d08321a36d96dbaa63f217