### PR TITLE
test: add component tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "vitest": "^1.6.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.5.2",
     "jsdom": "^24.0.0"
   }
 }

--- a/frontend/src/__tests__/RecordingControls.test.tsx
+++ b/frontend/src/__tests__/RecordingControls.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RecordingControls } from '../components/RecordingControls';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/path', () => ({ appDataDir: vi.fn() }));
+import { invoke } from '@tauri-apps/api/core';
+const invokeMock = vi.mocked(invoke);
+
+describe('RecordingControls', () => {
+  const barHeights = ['4px', '4px', '4px'];
+
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it('starts recording when start button is clicked', async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+    const onStart = vi.fn();
+    render(
+      <RecordingControls
+        isRecording={false}
+        barHeights={barHeights}
+        onRecordingStart={onStart}
+        onRecordingStop={vi.fn()}
+        onTranscriptReceived={vi.fn()}
+      />
+    );
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith('start_recording'));
+    expect(onStart).toHaveBeenCalled();
+  });
+
+  it('handles errors when starting the recording fails', async () => {
+    invokeMock.mockResolvedValueOnce(undefined); // for is_recording check
+    invokeMock.mockRejectedValueOnce(new Error('fail'));
+    const onStart = vi.fn();
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    render(
+      <RecordingControls
+        isRecording={false}
+        barHeights={barHeights}
+        onRecordingStart={onStart}
+        onRecordingStop={vi.fn()}
+        onTranscriptReceived={vi.fn()}
+      />
+    );
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    await waitFor(() => expect(invokeMock).toHaveBeenCalledWith('start_recording'));
+    expect(onStart).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Failed to start recording. Please check the console for details.'
+    );
+    alertSpy.mockRestore();
+  });
+
+  it('shows countdown when stop button is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <RecordingControls
+        isRecording={true}
+        barHeights={barHeights}
+        onRecordingStart={vi.fn()}
+        onRecordingStop={vi.fn()}
+        onTranscriptReceived={vi.fn()}
+      />
+    );
+    const button = screen.getByRole('button');
+    await user.click(button);
+    expect(screen.getByText('5s')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/TranscriptView.test.tsx
+++ b/frontend/src/__tests__/TranscriptView.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { TranscriptView } from '../components/TranscriptView';
+import { Transcript } from '../types';
+
+describe('TranscriptView', () => {
+  it('renders transcripts and scrolls to bottom on update', async () => {
+    const first: Transcript[] = [{ id: '1', text: 'Hello', timestamp: '00:00' }];
+    const { container, rerender } = render(<TranscriptView transcripts={first} />);
+
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+
+    const div = container.firstChild as HTMLDivElement;
+    Object.defineProperty(div, 'scrollHeight', { configurable: true, value: 100 });
+    div.scrollTop = 0;
+
+    const second = [...first, { id: '2', text: 'World', timestamp: '00:01' }];
+    rerender(<TranscriptView transcripts={second} />);
+    expect(screen.getByText('World')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(div.scrollTop).toBe(100);
+    });
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,7 +1,19 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
   },
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add RecordingControls and TranscriptView tests with mocked Tauri APIs
- configure Vitest with jest-dom setup and path aliases
- include user-event library for interaction testing
- cover start_recording error path to validate error handling

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68965d6595c48321bf4394bce3813667